### PR TITLE
Remove stale build_linear_operator export

### DIFF
--- a/src/SymbolicTracingUtils.jl
+++ b/src/SymbolicTracingUtils.jl
@@ -11,7 +11,6 @@ using FastDifferentiation: FastDifferentiation as FD
 using SparseArrays: SparseArrays
 
 export build_function,
-    build_linear_operator,
     FastDifferentiationBackend,
     get_constant_entries,
     get_result_buffer,


### PR DESCRIPTION
## Summary

`build_linear_operator` was removed in the Symbolics 7 upgrade (#7), but its entry in the `export` list was left behind. This triggers an undefined-export warning when running `using SymbolicTracingUtils`. This PR drops the stale export.

## Changes

- Remove `build_linear_operator` from the `export` block in `src/SymbolicTracingUtils.jl`.

## Verification

`julia --project=. -e 'using SymbolicTracingUtils'` now loads cleanly with no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)